### PR TITLE
avoid warning when clicking on blank square

### DIFF
--- a/Mine Blower.py
+++ b/Mine Blower.py
@@ -255,7 +255,7 @@ def click(square, auto=False, click_flag=False):
             for r,c in squares_around:
                 tk_square = square_to_widget(r, c)
                 click(tk_square, auto=True, click_flag=True)
-    elif auto == False:  # clicking on a number
+    elif auto == False and currentText != "  ":  # clicking on a number
         squares_around = surrounding_squares(row, column)
         flag_count = 0
         for r,c in squares_around:


### PR DESCRIPTION
When clicking on an opened square that has no mines around it,
it will have the text "  " as currentText.
In this case we should just ignore such clicks,
which is more efficient and also avoids the
warning displayed when trying to convert "  " with int().